### PR TITLE
Docker設定の修正（restart設定の無効化）

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   db:
     image: postgres:13
-    restart: always
+    restart: "no"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
* **再起動設定の明示化**
    * 他プロジェクトとのポート競合や、Docker起動時に意図せずコンテナが立ち上がるのを防ぐため、`restart` 設定を `"no"` に変更・明示しました。